### PR TITLE
feat: add check for unsafe-keys

### DIFF
--- a/src/helpers/path-to-array.ts
+++ b/src/helpers/path-to-array.ts
@@ -5,6 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { isUnsafeKey } from '../utils';
+
 export const BRACKET_NUMBER_REGEX = /(?<!\\)\[(\d+)]$/;
 
 /**
@@ -33,11 +35,7 @@ export function pathToArray(segment: PropertyKey) : PropertyKey[] {
     const result : PropertyKey[] = [];
 
     for (const part of parts) {
-        if (
-            part === 'constructor' ||
-            part === '__proto__' ||
-            part === 'prototype'
-        ) {
+        if (isUnsafeKey(part)) {
             continue;
         }
 

--- a/src/path-info/module.ts
+++ b/src/path-info/module.ts
@@ -7,6 +7,7 @@
 
 import { getPathValue } from '../path-value';
 import { pathToArray } from '../helpers';
+import { isUnsafeKey } from '../utils';
 
 export class PathInfo {
     protected data: unknown;
@@ -23,7 +24,7 @@ export class PathInfo {
         this.data = data;
 
         if (Array.isArray(path)) {
-            this.pathParts = path;
+            this.pathParts = path.filter((p) => !isUnsafeKey(p));
         } else {
             this.pathParts = pathToArray(path);
         }

--- a/src/path-value/get.ts
+++ b/src/path-value/get.ts
@@ -6,6 +6,7 @@
  */
 
 import { pathToArray } from '../helpers';
+import { isUnsafeKey } from '../utils';
 
 export function getPathValue(
     data: unknown,
@@ -20,6 +21,10 @@ export function getPathValue(
     let index = 0;
     while (index < parts.length) {
         if (temp === null || typeof temp === 'undefined') {
+            break;
+        }
+
+        if (isUnsafeKey(parts[index])) {
             break;
         }
 

--- a/src/path-value/set.ts
+++ b/src/path-value/set.ts
@@ -6,7 +6,7 @@
  */
 
 import { pathToArray } from '../helpers';
-import { isObject } from '../utils';
+import { isObject, isUnsafeKey } from '../utils';
 
 const NUMBER_REGEX = /^\d+$/;
 
@@ -28,6 +28,10 @@ export function setPathValue(
         }
 
         const key = parts[index] as keyof typeof temp;
+
+        if (isUnsafeKey(key)) {
+            break;
+        }
 
         // [foo, '0']
         if (typeof temp[key] === 'undefined') {

--- a/src/remove.ts
+++ b/src/remove.ts
@@ -6,7 +6,7 @@
  */
 
 import { pathToArray } from './helpers';
-import { isObject } from './utils';
+import { isObject, isUnsafeKey } from './utils';
 
 export function removePath(
     data: Record<string, any> | Record<string, any>[],
@@ -25,6 +25,10 @@ export function removePath(
         }
 
         const key = parts[index] as keyof typeof temp;
+
+        if (isUnsafeKey(key)) {
+            break;
+        }
 
         if (!Object.prototype.hasOwnProperty.call(temp, key)) {
             break;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './is-object';
+export * from './is-unsafe-key';

--- a/src/utils/is-unsafe-key.ts
+++ b/src/utils/is-unsafe-key.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024-2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+const UNSAFE_KEYS = new Set<PropertyKey>(['__proto__', 'constructor', 'prototype']);
+
+export function isUnsafeKey(key: PropertyKey): boolean {
+    return UNSAFE_KEYS.has(key);
+}

--- a/test/unit/get-path-value.spec.ts
+++ b/test/unit/get-path-value.spec.ts
@@ -43,3 +43,27 @@ describe('getPathValue', () => {
         expect(getPathValue('word', 'length')).toEqual(4);
     });
 });
+
+describe('avoid prototype pollution vulnerability', () => {
+    it('exclude __proto__ via array path', () => {
+        const obj = {};
+        expect(getPathValue(obj, ['__proto__', 'constructor'])).toBeUndefined();
+    });
+
+    it('exclude __proto__ at non-first position via array path', () => {
+        const obj = {
+            a: {},
+        };
+        expect(getPathValue(obj, ['a', '__proto__', 'constructor'])).toBeUndefined();
+    });
+
+    it('exclude constructor via array path', () => {
+        const obj = {};
+        expect(getPathValue(obj, ['constructor', 'prototype'])).toBeUndefined();
+    });
+
+    it('exclude prototype via array path', () => {
+        const obj = {};
+        expect(getPathValue(obj, ['prototype', 'toString'])).toBeUndefined();
+    });
+});

--- a/test/unit/remove-path.spec.ts
+++ b/test/unit/remove-path.spec.ts
@@ -50,3 +50,40 @@ describe('removePath', () => {
         expect(object).toEqual(object);
     });
 });
+
+describe('avoid prototype pollution vulnerability', () => {
+    it('exclude __proto__ via string path', () => {
+        const obj : Record<string, any> = {};
+        removePath(obj, '__proto__');
+        expect(typeof obj.constructor).toEqual('function');
+    });
+
+    it('exclude constructor via string path', () => {
+        const obj : Record<string, any> = {};
+        removePath(obj, 'constructor');
+        expect(typeof obj.constructor).toEqual('function');
+    });
+
+    it('exclude __proto__ via array path', () => {
+        const obj : Record<string, any> = {};
+        removePath(obj, ['__proto__', 'polluted']);
+        expect(obj.polluted).toBeUndefined();
+        expect((Object.prototype as any).polluted).toBeUndefined();
+    });
+
+    it('exclude __proto__ at non-first position via array path', () => {
+        const obj : Record<string, any> = {
+            a: {},
+        };
+        removePath(obj, ['a', '__proto__', 'toString']);
+        expect(obj.a.toString).toBeDefined();
+        expect((Object.prototype as any).toString).toBeDefined();
+    });
+
+    it('exclude constructor via array path', () => {
+        const obj : Record<string, any> = {};
+        removePath(obj, ['constructor', 'prototype']);
+        expect(typeof obj.constructor).toEqual('function');
+        expect((Object.prototype as any).constructor).toBeDefined();
+    });
+});

--- a/test/unit/set-path-value.spec.ts
+++ b/test/unit/set-path-value.spec.ts
@@ -119,4 +119,27 @@ describe('avoid prototype pollution vulnerability', () => {
         setPathValue(obj, 'prototype', true);
         expect(obj.prototype).toBeUndefined();
     });
+
+    it('exclude __proto__ via array path', () => {
+        const obj : Record<string, any> = {};
+        setPathValue(obj, ['__proto__', 'polluted'], 'yes');
+        expect(obj.polluted).toBeUndefined();
+        expect((Object.prototype as any).polluted).toBeUndefined();
+    });
+
+    it('exclude __proto__ at non-first position via array path', () => {
+        const obj : Record<string, any> = {
+            a: {},
+        };
+        setPathValue(obj, ['a', '__proto__', 'polluted'], 'yes');
+        expect(obj.a.polluted).toBeUndefined();
+        expect((Object.prototype as any).polluted).toBeUndefined();
+    });
+
+    it('exclude constructor via array path', () => {
+        const obj : Record<string, any> = {};
+        setPathValue(obj, ['constructor', 'prototype', 'polluted'], 'yes');
+        expect(obj.polluted).toBeUndefined();
+        expect((Object.prototype as any).polluted).toBeUndefined();
+    });
 });

--- a/test/unit/set-path-value.spec.ts
+++ b/test/unit/set-path-value.spec.ts
@@ -142,4 +142,11 @@ describe('avoid prototype pollution vulnerability', () => {
         expect(obj.polluted).toBeUndefined();
         expect((Object.prototype as any).polluted).toBeUndefined();
     });
+
+    it('exclude prototype via array path', () => {
+        const obj : Record<string, any> = {};
+        setPathValue(obj, ['prototype', 'polluted'], 'yes');
+        expect(obj.polluted).toBeUndefined();
+        expect((Object.prototype as any).polluted).toBeUndefined();
+    });
 });


### PR DESCRIPTION
closes #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened runtime protections against prototype-pollution: path-based get/set/remove operations now block reserved keys like __proto__, constructor, and prototype to prevent unsafe property access or mutation.

* **Tests**
  * Added unit tests covering array and string paths that include reserved keys to verify no global prototype pollution occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->