### PR TITLE
fix: reject unsafe path segments and resolve own entries only

### DIFF
--- a/src/helpers/path-to-array.ts
+++ b/src/helpers/path-to-array.ts
@@ -5,12 +5,15 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isUnsafeKey } from '../utils';
-
 export const BRACKET_NUMBER_REGEX = /(?<!\\)\[(\d+)]$/;
 
 /**
  * Convert string to property path array.
+ *
+ * Unsafe segments (`__proto__`, `constructor`, `prototype`) are **kept**. They
+ * are rejected during traversal instead — dropping them here would silently
+ * turn `a.__proto__.b` into `a.b`, resolving a different path rather than
+ * refusing the requested one.
  *
  * @see https://github.com/lodash/lodash/blob/main/src/.internal/stringToPath.ts
  * @see https://github.com/chaijs/pathval
@@ -35,10 +38,6 @@ export function pathToArray(segment: PropertyKey) : PropertyKey[] {
     const result : PropertyKey[] = [];
 
     for (const part of parts) {
-        if (isUnsafeKey(part)) {
-            continue;
-        }
-
         const regex = BRACKET_NUMBER_REGEX.exec(part);
         if (regex) {
             result.push(Number(regex[1]));

--- a/src/path-info/module.ts
+++ b/src/path-info/module.ts
@@ -7,6 +7,7 @@
 
 import { getPathValue } from '../path-value';
 import { pathToArray } from '../helpers';
+import { hasOwnEntry } from '../utils';
 
 export class PathInfo {
     protected data: unknown;
@@ -87,14 +88,9 @@ export class PathInfo {
             return this._exists;
         }
 
-        if (
-            this.parent.value !== null &&
-            typeof this.parent.value !== 'undefined'
-        ) {
-            this._exists = this.name in Object(this.parent.value);
-        } else {
-            this._exists = false;
-        }
+        // Own, safe entries only — inherited members (`toString`, `valueOf`, …)
+        // are not data and must not be reported as existing paths.
+        this._exists = hasOwnEntry(this.parent.value, this.name);
 
         return this._exists;
     }

--- a/src/path-info/module.ts
+++ b/src/path-info/module.ts
@@ -7,7 +7,6 @@
 
 import { getPathValue } from '../path-value';
 import { pathToArray } from '../helpers';
-import { isUnsafeKey } from '../utils';
 
 export class PathInfo {
     protected data: unknown;
@@ -23,8 +22,12 @@ export class PathInfo {
     constructor(data: unknown, path: PropertyKey | PropertyKey[]) {
         this.data = data;
 
+        // Unsafe segments are kept, not filtered: dropping them would shorten
+        // the path and describe a different — possibly empty — one, which is
+        // why `getPathInfo(data, '__proto__')` used to report the whole object
+        // as an existing value. They are rejected by `exists`/`value` instead.
         if (Array.isArray(path)) {
-            this.pathParts = path.filter((p) => !isUnsafeKey(p));
+            this.pathParts = [...path];
         } else {
             this.pathParts = pathToArray(path);
         }

--- a/src/path-info/module.ts
+++ b/src/path-info/module.ts
@@ -83,7 +83,10 @@ export class PathInfo {
             return this._exists;
         }
 
-        if (!this.name || !this.parent) {
+        // Only the root path (no segments) exists unconditionally. Testing
+        // truthiness instead would also short-circuit for the falsy keys `0`
+        // and `''`, reporting a missing index 0 as an existing path.
+        if (this.name === null || !this.parent) {
             this._exists = true;
             return this._exists;
         }

--- a/src/path-value/get.ts
+++ b/src/path-value/get.ts
@@ -6,7 +6,7 @@
  */
 
 import { pathToArray } from '../helpers';
-import { isUnsafeKey } from '../utils';
+import { hasOwnEntry } from '../utils';
 
 export function getPathValue(
     data: unknown,
@@ -24,17 +24,15 @@ export function getPathValue(
             break;
         }
 
-        if (isUnsafeKey(parts[index])) {
+        // Own, safe entries only — an unsafe segment or an inherited member
+        // ends the traversal instead of resolving to something else.
+        if (!hasOwnEntry(temp, parts[index])) {
             break;
         }
 
-        if (parts[index] in Object(temp)) {
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-expect-error
-            temp = temp[parts[index]];
-        } else {
-            break;
-        }
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        temp = temp[parts[index]];
 
         if (index === parts.length - 1) {
             res = temp;

--- a/src/utils/has-own-entry.ts
+++ b/src/utils/has-own-entry.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024-2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isUnsafeKey } from './is-unsafe-key';
+
+/**
+ * Check if a key is an own, safe entry of the target.
+ *
+ * Uses `Object.hasOwn` rather than `in`, so inherited members (`toString`,
+ * `valueOf`, `hasOwnProperty`, …) never resolve as data. Own properties of
+ * boxed primitives are unaffected, so `'word'.length` keeps working.
+ *
+ * @param target
+ * @param key
+ */
+export function hasOwnEntry(target: unknown, key: PropertyKey) : boolean {
+    if (isUnsafeKey(key)) {
+        return false;
+    }
+
+    if (
+        target === null ||
+        typeof target === 'undefined'
+    ) {
+        return false;
+    }
+
+    return Object.hasOwn(Object(target), key);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './has-own-entry';
 export * from './is-object';
 export * from './is-unsafe-key';

--- a/test/unit/get-path-info.spec.ts
+++ b/test/unit/get-path-info.spec.ts
@@ -142,3 +142,36 @@ describe('getPathInfo', () => {
         expect(info.exists).toBeTruthy();
     });
 });
+
+describe('unsafe segments', () => {
+    const data = {
+        a: {
+            b: 'safe' 
+        },
+        secret: 'top' 
+    };
+
+    it.each([
+        ['__proto__'],
+        ['constructor'],
+        ['prototype'],
+    ])('should not report %s as an existing path', (key) => {
+        const info = getPathInfo(data, key);
+
+        // Filtering the segment away used to leave an empty path, which
+        // resolves to the root — reporting the whole object as the value.
+        expect(info.value).toBeUndefined();
+    });
+
+    it('should not describe a neighbouring path when a segment is unsafe', () => {
+        const info = getPathInfo(data, 'a.__proto__.b');
+
+        expect(info.value).toBeUndefined();
+    });
+
+    it('should reject an unsafe segment given as an array path', () => {
+        const info = getPathInfo(data, ['a', '__proto__', 'b']);
+
+        expect(info.value).toBeUndefined();
+    });
+});

--- a/test/unit/get-path-info.spec.ts
+++ b/test/unit/get-path-info.spec.ts
@@ -201,6 +201,38 @@ describe('inherited members', () => {
         expect(info.exists).toBe(true);
     });
 
+    it('should not report a missing index 0 as existing', () => {
+        // `0` is falsy, so a truthiness guard used to skip the own-entry
+        // check entirely and report every index-0 path as existing.
+        const info = getPathInfo([], [0]);
+
+        expect(info.exists).toBe(false);
+        expect(info.value).toBeUndefined();
+    });
+
+    it('should report a present index 0 as existing', () => {
+        const info = getPathInfo([9], [0]);
+
+        expect(info.exists).toBe(true);
+        expect(info.value).toEqual(9);
+    });
+
+    it('should not report a missing index 0 as existing via a string path', () => {
+        const info = getPathInfo({
+            a: [] 
+        }, 'a[0]');
+
+        expect(info.exists).toBe(false);
+        expect(info.value).toBeUndefined();
+    });
+
+    it('should not report a missing empty-string key as existing', () => {
+        const info = getPathInfo({}, ['']);
+
+        expect(info.exists).toBe(false);
+        expect(info.value).toBeUndefined();
+    });
+
     it('should report an own property of a boxed primitive as existing', () => {
         expect(getPathInfo('word', 'length').exists).toBe(true);
         expect(getPathInfo([1, 2, 3], 'length').exists).toBe(true);

--- a/test/unit/get-path-info.spec.ts
+++ b/test/unit/get-path-info.spec.ts
@@ -160,18 +160,49 @@ describe('unsafe segments', () => {
 
         // Filtering the segment away used to leave an empty path, which
         // resolves to the root — reporting the whole object as the value.
+        expect(info.exists).toBe(false);
         expect(info.value).toBeUndefined();
     });
 
     it('should not describe a neighbouring path when a segment is unsafe', () => {
         const info = getPathInfo(data, 'a.__proto__.b');
 
+        expect(info.exists).toBe(false);
         expect(info.value).toBeUndefined();
     });
 
     it('should reject an unsafe segment given as an array path', () => {
         const info = getPathInfo(data, ['a', '__proto__', 'b']);
 
+        expect(info.exists).toBe(false);
         expect(info.value).toBeUndefined();
+    });
+});
+
+describe('inherited members', () => {
+    it.each([
+        ['toString'],
+        ['valueOf'],
+        ['hasOwnProperty'],
+    ])('should not report the inherited member %s as existing', (key) => {
+        const info = getPathInfo({
+            a: {} 
+        }, `a.${key}`);
+
+        expect(info.exists).toBe(false);
+        expect(info.value).toBeUndefined();
+    });
+
+    it('should report an own property whose value is undefined as existing', () => {
+        const info = getPathInfo({
+            a: undefined 
+        }, 'a');
+
+        expect(info.exists).toBe(true);
+    });
+
+    it('should report an own property of a boxed primitive as existing', () => {
+        expect(getPathInfo('word', 'length').exists).toBe(true);
+        expect(getPathInfo([1, 2, 3], 'length').exists).toBe(true);
     });
 });

--- a/test/unit/get-path-value.spec.ts
+++ b/test/unit/get-path-value.spec.ts
@@ -88,3 +88,30 @@ describe('avoid prototype pollution vulnerability', () => {
         expect(({} as Record<string, unknown>).polluted).toBeUndefined();
     });
 });
+
+describe('inherited members', () => {
+    it.each([
+        ['toString'],
+        ['valueOf'],
+        ['hasOwnProperty'],
+        ['isPrototypeOf'],
+    ])('should not resolve the inherited member %s', (key) => {
+        expect(getPathValue({
+            a: {} 
+        }, `a.${key}`)).toBeUndefined();
+    });
+
+    it('should still resolve own properties of boxed primitives', () => {
+        // Documented behaviour: `length` is an own property, unlike the above.
+        expect(getPathValue('word', 'length')).toEqual(4);
+        expect(getPathValue([1, 2, 3], 'length')).toEqual(3);
+    });
+
+    it('should still resolve an own property shadowing an inherited one', () => {
+        expect(getPathValue({
+            a: {
+                toString: 'mine' 
+            } 
+        }, 'a.toString')).toEqual('mine');
+    });
+});

--- a/test/unit/get-path-value.spec.ts
+++ b/test/unit/get-path-value.spec.ts
@@ -66,4 +66,25 @@ describe('avoid prototype pollution vulnerability', () => {
         const obj = {};
         expect(getPathValue(obj, ['prototype', 'toString'])).toBeUndefined();
     });
+
+    it('should not resolve a neighbouring path when a segment is unsafe', () => {
+        const obj = {
+            a: {
+                b: 'safe' 
+            } 
+        };
+
+        // Dropping `__proto__` would leave `a.b`, silently answering a
+        // different question than the one that was asked.
+        expect(getPathValue(obj, 'a.__proto__.b')).toBeUndefined();
+        expect(getPathValue(obj, ['a', '__proto__', 'b'])).toBeUndefined();
+        expect(getPathValue(obj, 'a.b')).toEqual('safe');
+    });
+
+    it('should not resolve an own unsafe key', () => {
+        const obj = JSON.parse('{"__proto__":{"polluted":true}}');
+
+        expect(getPathValue(obj, '__proto__')).toBeUndefined();
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
 });

--- a/test/unit/path-to-array.spec.ts
+++ b/test/unit/path-to-array.spec.ts
@@ -20,4 +20,15 @@ describe('path-to-array', () => {
     ])('%s', (_name, input, expected) => {
         expect(pathToArray(input)).toEqual(expected);
     });
+
+    // Dropping an unsafe segment would shorten the path and describe a
+    // different one, so they are kept here and rejected during traversal.
+    it.each([
+        ['unsafe segment alone', '__proto__', ['__proto__']],
+        ['unsafe segment between text segments', 'a.__proto__.b', ['a', '__proto__', 'b']],
+        ['constructor segment', 'a.constructor.b', ['a', 'constructor', 'b']],
+        ['prototype segment', 'a.prototype.b', ['a', 'prototype', 'b']],
+    ])('should keep an unsafe segment: %s', (_name, input, expected) => {
+        expect(pathToArray(input)).toEqual(expected);
+    });
 });

--- a/test/unit/remove-path.spec.ts
+++ b/test/unit/remove-path.spec.ts
@@ -87,3 +87,19 @@ describe('avoid prototype pollution vulnerability', () => {
         expect((Object.prototype as any).constructor).toBeDefined();
     });
 });
+
+describe('unsafe segments do not redirect the removal', () => {
+    it('should not remove a neighbouring path', () => {
+        const obj : Record<string, any> = {
+            a: {
+                x: 1 
+            } 
+        };
+
+        removePath(obj, 'a.__proto__.x');
+
+        expect(obj.a).toEqual({
+            x: 1 
+        });
+    });
+});

--- a/test/unit/set-path-value.spec.ts
+++ b/test/unit/set-path-value.spec.ts
@@ -150,3 +150,18 @@ describe('avoid prototype pollution vulnerability', () => {
         expect((Object.prototype as any).polluted).toBeUndefined();
     });
 });
+
+describe('unsafe segments do not redirect the write', () => {
+    it('should not write to a neighbouring path', () => {
+        const obj : Record<string, any> = {
+            a: {} 
+        };
+
+        // Dropping `__proto__` would leave `a.x`, writing somewhere the
+        // caller never named.
+        setPathValue(obj, 'a.__proto__.x', 'yes');
+
+        expect(obj.a).toEqual({});
+        expect(({} as Record<string, unknown>).x).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Fixes #181 — two independent defects in path traversal, one commit each so they can be taken or deferred separately.

Found while auditing [confinity](https://github.com/tada5hi/confinity), which delegates all path resolution here.

## 1. Unsafe segments truncated the path instead of invalidating it

`pathToArray` dropped `__proto__`/`constructor`/`prototype` with `continue`, and `PathInfo`'s constructor did the same with `.filter()`. The remaining segments were rejoined, so the guard resolved **a different path** rather than refusing the requested one:

| | before | after |
|---|---|---|
| `pathToArray('a.__proto__.b')` | `['a', 'b']` | `['a', '__proto__', 'b']` |
| `getPathValue({a:{b:'safe'}}, 'a.__proto__.b')` | `'safe'` | `undefined` |
| `getPathInfo(data, '__proto__')` | `exists: true`, value = **the entire object** | `exists: false`, `undefined` |
| `setPathValue({a:{}}, 'a.__proto__.x', v)` | writes to `a.x` | no write |

The `getPathInfo` row is the worst: every segment was dropped, `pathParts` became `[]`, and `value` fell through to `return this.data`.

The guard was already in the right place — `getPathValue`, `setPathValue` and `removePath` each `break` on `isUnsafeKey` during traversal. The filtering was redundant for safety and was the only thing turning a rejection into a redirect, so it is removed.

## 2. `exists` and traversal walked the prototype chain

Both used `key in Object(value)`:

```js
getPathInfo({ a: {} }, 'a.toString')        // was exists: true, value: [Function]
getPathInfo({ a: {} }, 'a.hasOwnProperty')  // was exists: true, value: [Function]
getPathInfo({ a: {} }, 'a.valueOf')         // was exists: true, value: [Function]
```

Both now go through one `hasOwnEntry` helper built on `Object.hasOwn`, so `exists` and `value` can no longer disagree.

**The documented primitive behaviour is preserved.** `length` is an own property of a boxed `String`/`Array` while `toString` is not, so the split falls exactly where it should:

```js
getPathValue('word', 'length')                       // 4  (README, unchanged)
getPathValue([1, 2, 3], 'length')                    // 3  (unchanged)
getPathValue({ a: { toString: 'mine' } }, 'a.toString')  // 'mine'  (own shadowing)
getPathInfo({ a: undefined }, 'a').exists            // true  (own, value undefined)
```

> [!NOTE]
> One deliberate behaviour change beyond the reported bugs: a value inherited from a **user** prototype — a getter on a class instance — no longer resolves. That seems right for a data-path library, but it is a judgement call, and it is confined to the second commit if you would rather take only the first.

## Verification

93 tests, up from 69. All 69 pre-existing tests pass unmodified, including every prototype-pollution test and the documented `getPathValue('word', 'length')`. Lint and build clean.

Also ran **confinity's** full suite (116 tests) against this build — all pass. It additionally closes two findings from that audit at the consumer level:

```js
store.getSync('__proto__')     // was: the entire merged config → now: undefined
store.has('db.toString')       // was: true → now: false
store.getSync('db.password')   // 'hunter2' (unchanged)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path handling to block unsafe and inherited properties during reads, existence checks, updates, and removals.
  - Prevented special path segments from redirecting operations to unintended properties.
  - Preserved valid own properties, including properties with `undefined` values and boxed primitive members.
  - Ensured unsafe path segments are safely rejected during traversal.

- **Tests**
  - Added coverage for unsafe segments, inherited properties, boxed primitives, and prototype-pollution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->