### PR TITLE
fix: resolve accessors declared on a user prototype

### DIFF
--- a/src/utils/has-own-entry.ts
+++ b/src/utils/has-own-entry.ts
@@ -8,11 +8,20 @@
 import { isUnsafeKey } from './is-unsafe-key';
 
 /**
- * Check if a key is an own, safe entry of the target.
+ * Check if a key is a safe, readable entry of the target.
  *
- * Uses `Object.hasOwn` rather than `in`, so inherited members (`toString`,
- * `valueOf`, `hasOwnProperty`, …) never resolve as data. Own properties of
- * boxed primitives are unaffected, so `'word'.length` keeps working.
+ * Three rules, in order:
+ *
+ * 1. An **own** property always resolves — including one that shadows an
+ *    inherited name, and `length` on a boxed `String`/`Array`.
+ * 2. A name that **every** object inherits never resolves. Those are exactly
+ *    the own keys of `Object.prototype` (`toString`, `valueOf`,
+ *    `hasOwnProperty`, …) — a set fixed by the language, so there is no list to
+ *    keep up to date, and it holds for objects from another realm too, where
+ *    comparing prototype identity would not.
+ * 3. Anything else inherited resolves. A getter on a class prototype is data as
+ *    far as a caller is concerned and is indistinguishable from a plain field
+ *    at the call site.
  *
  * @param target
  * @param key
@@ -29,5 +38,15 @@ export function hasOwnEntry(target: unknown, key: PropertyKey) : boolean {
         return false;
     }
 
-    return Object.hasOwn(Object(target), key);
+    const source = Object(target);
+
+    if (Object.hasOwn(source, key)) {
+        return true;
+    }
+
+    if (Object.hasOwn(Object.prototype, key)) {
+        return false;
+    }
+
+    return key in source;
 }

--- a/test/unit/get-path-info.spec.ts
+++ b/test/unit/get-path-info.spec.ts
@@ -143,6 +143,25 @@ describe('getPathInfo', () => {
     });
 });
 
+/**
+ * Build an object whose `key` is an accessor on its **prototype**, the shape a
+ * class instance with a getter has. `levels` adds intermediate prototypes, so a
+ * subclass chain can be exercised too.
+ */
+function withPrototypeAccessor(key: string, value: unknown, levels = 1) : object {
+    let prototype : object = {};
+    Object.defineProperty(prototype, key, {
+        get: () => value,
+        configurable: true 
+    });
+
+    for (let i = 1; i < levels; i++) {
+        prototype = Object.create(prototype);
+    }
+
+    return Object.create(prototype);
+}
+
 describe('unsafe segments', () => {
     const data = {
         a: {
@@ -231,6 +250,49 @@ describe('inherited members', () => {
 
         expect(info.exists).toBe(false);
         expect(info.value).toBeUndefined();
+    });
+
+    it('should resolve an accessor declared on a user prototype', () => {
+        // A getter on a class is data at the call site — indistinguishable from
+        // a field — unlike anything inherited from Object.prototype.
+        const info = getPathInfo({
+            identity: withPrototypeAccessor('id', 'abc') 
+        }, 'identity.id');
+
+        expect(info.exists).toBe(true);
+        expect(info.value).toEqual('abc');
+    });
+
+    it('should resolve an accessor inherited through a subclass chain', () => {
+        const identity = withPrototypeAccessor('realmId', 'master', 3);
+        const info = getPathInfo({
+            identity 
+        }, 'identity.realmId');
+
+        expect(info.exists).toBe(true);
+        expect(info.value).toEqual('master');
+    });
+
+    it('should not resolve a universally inherited member on a cross-realm object', () => {
+        // A foreign Object.prototype stands in for another realm: comparing
+        // prototype identity would miss it, the key-name rule does not.
+        const foreignPrototype = Object.create(null);
+        Object.defineProperty(foreignPrototype, 'toString', {
+            value: () => 'x',
+            configurable: true,
+        });
+
+        expect(getPathInfo({
+            o: Object.create(foreignPrototype) 
+        }, 'o.toString').exists).toBe(false);
+    });
+
+    it('should not resolve a universally inherited member on such an object', () => {
+        const info = getPathInfo({
+            identity: withPrototypeAccessor('id', 'abc') 
+        }, 'identity.toString');
+
+        expect(info.exists).toBe(false);
     });
 
     it('should report an own property of a boxed primitive as existing', () => {

--- a/test/unit/get-path-value.spec.ts
+++ b/test/unit/get-path-value.spec.ts
@@ -101,6 +101,18 @@ describe('inherited members', () => {
         }, `a.${key}`)).toBeUndefined();
     });
 
+    it('should resolve an accessor declared on a user prototype', () => {
+        const prototype = {};
+        Object.defineProperty(prototype, 'id', {
+            get: () => 'abc',
+            configurable: true 
+        });
+
+        expect(getPathValue({
+            identity: Object.create(prototype) 
+        }, 'identity.id')).toEqual('abc');
+    });
+
     it('should still resolve own properties of boxed primitives', () => {
         // Documented behaviour: `length` is an own property, unlike the above.
         expect(getPathValue('word', 'length')).toEqual(4);


### PR DESCRIPTION
Regression from #182 (released as 2.2.1). Swapping `in` for `Object.hasOwn` also stopped resolving members declared on a **class prototype** — a getter is data as far as a caller is concerned, indistinguishable from a plain field at the call site.

I flagged this as a judgement call in #182; it turns out to be load-bearing in practice, so this reverses that decision.

## How it surfaced

authup's policy evaluation resolves `id` / `realmId` / `clientId` / `type` / `realmName` against a `RequestIdentity` whose accessors live on the prototype. Under 2.2.1 every one of those returned nothing, and every permission check failed:

```
HttpResponseError: The evaluation of permission user_create failed
  ❯ UserAPI.create  packages/core-http-kit/src/domains/entities/user/module.ts:63:16
```

Bisected to the exact commit, then instrumented `hasOwnEntry` to log where `Object.hasOwn` and `in` disagree:

```
[pathtrace-divergence] key=id        ctor=RequestIdentity proto=custom
[pathtrace-divergence] key=realmId   ctor=RequestIdentity proto=custom
[pathtrace-divergence] key=clientId  ctor=RequestIdentity proto=custom
```

## The rule now

Three ordered checks instead of one:

1. An **own** property always resolves — including one shadowing an inherited name, and `length` on a boxed `String`/`Array`.
2. A name that **every** object inherits never resolves — exactly the own keys of `Object.prototype` (`toString`, `valueOf`, `hasOwnProperty`, …). This is what #181 actually reported.
3. Anything else inherited resolves.

```ts
const source = Object(target);

if (Object.hasOwn(source, key)) return true;
if (Object.hasOwn(Object.prototype, key)) return false;

return key in source;
```

Rule 2 is deliberately a **key-name** test rather than a prototype-identity test. An earlier draft kept a `Set` of intrinsic prototypes to stop at; that is not robust — it misses built-ins added later, and it fails across realms, where an iframe's `Object.prototype` is not identical to ours. Testing the key name needs no list and holds cross-realm. There is a regression test for that case.

## What is unaffected

Everything #181 and #182 fixed still holds — unsafe segments still invalidate a path rather than truncating it, `toString`/`valueOf`/`hasOwnProperty` still do not resolve as data, and a missing index `0` is still reported as non-existent.

```js
getPathInfo({ a: {} }, 'a.toString').exists                    // false
getPathValue({ a: { b: 'safe' } }, 'a.__proto__.b')            // undefined
getPathInfo({ a: [] }, 'a[0]').exists                          // false
getPathValue('word', 'length')                                 // 4
getPathValue({ a: { toString: 'mine' } }, 'a.toString')        // 'mine'
```

## Verification

- pathtrace: **102 tests** (up from 97), lint and build clean
- authup token workflows — the suites that broke — **17 files / 85 tests pass**; they fail on 2.2.1
- authup config + launcher suites — 35 and 30 pass
- confinity — 122 pass

Worth a prompt 2.2.2: 2.2.1 is the version confinity 2.0.0 requires, so anyone resolving paths against class instances is affected today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property path resolution for inherited properties and prototype accessors.
  * Preserved safe handling of built-in object members and unsafe keys.
  * Added support for resolving accessor values through custom prototype chains.
  * Improved behavior for boxed primitive values and shadowed properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->