### PR TITLE
fix(set-path-value): decide intermediate container kind from the next segment

### DIFF
--- a/src/path-value/set.ts
+++ b/src/path-value/set.ts
@@ -10,6 +10,33 @@ import { isObject, isUnsafeKey } from '../utils';
 
 const NUMBER_REGEX = /^\d+$/;
 
+/** Largest value a real array index can take: 2^32 - 2. */
+const MAX_ARRAY_INDEX = 4294967294;
+
+/**
+ * Whether `key` is a *canonical* array index, per the spec definition: a
+ * property key is an array index only when `String(ToUint32(key)) === key`
+ * and it is below 2^32 - 1.
+ *
+ * A digit-only test is not enough. `'01'`, `'007'`, `'4294967295'` and
+ * `'99999999999999999999'` all match `/^\d+$/` but are ordinary string
+ * properties — assigning them onto an array produces a non-index property,
+ * which `JSON.stringify` and `structuredClone` silently discard. Those keys
+ * therefore need a plain object, not an array.
+ */
+function isArrayIndex(key: unknown): boolean {
+    const str = typeof key === 'number' ? String(key) : key;
+
+    if (typeof str !== 'string' || !NUMBER_REGEX.test(str)) {
+        return false;
+    }
+
+    const num = Number(str);
+
+    return num <= MAX_ARRAY_INDEX &&
+        String(num) === str;
+}
+
 export function setPathValue(
     data: Record<string, any> | Record<string, any>[],
     path: string | string[],
@@ -41,11 +68,11 @@ export function setPathValue(
         // Materialize the intermediate this key points at.
         //
         // The container kind is decided by the *next* segment, not this one:
-        // a numeric next segment means the slot is about to be indexed
-        // numerically, so it has to be an array. Reading the current key
-        // instead would build `{ a: { '0': [] } }` for `a[0].b` — an array
-        // at the index, with `b` hung off it as a non-index property, which
-        // JSON.stringify and structuredClone both discard.
+        // a canonical array index as the next segment means the slot is
+        // about to be indexed, so it has to be an array. Reading the current
+        // key instead would build `{ a: { '0': [] } }` for `a[0].b` — an
+        // array at the index, with `b` hung off it as a non-index property,
+        // which JSON.stringify and structuredClone both discard.
         const existing = temp[key];
         if (!isObject(existing) && !Array.isArray(existing)) {
             // Same "can this be descended into?" test the loop head uses.
@@ -53,7 +80,7 @@ export function setPathValue(
             // primitive. Replacing a primitive matches lodash `_.set` and
             // the caller's explicit intent; leaving it in place made the
             // write vanish with no signal.
-            (temp as Record<string, any>)[key] = NUMBER_REGEX.test(parts[index + 1] as string) ?
+            (temp as Record<string, any>)[key] = isArrayIndex(parts[index + 1]) ?
                 [] :
                 {};
         }

--- a/src/path-value/set.ts
+++ b/src/path-value/set.ts
@@ -33,19 +33,29 @@ export function setPathValue(
             break;
         }
 
-        // [foo, '0']
-        if (typeof temp[key] === 'undefined') {
-            const match = NUMBER_REGEX.test(key);
-            if (match) {
-                (temp as Record<string, any>)[key] = [];
-            } else {
-                temp[key] = {};
-            }
-        }
-
         if (index === parts.length - 1) {
             temp[key] = value;
             break;
+        }
+
+        // Materialize the intermediate this key points at.
+        //
+        // The container kind is decided by the *next* segment, not this one:
+        // a numeric next segment means the slot is about to be indexed
+        // numerically, so it has to be an array. Reading the current key
+        // instead would build `{ a: { '0': [] } }` for `a[0].b` — an array
+        // at the index, with `b` hung off it as a non-index property, which
+        // JSON.stringify and structuredClone both discard.
+        const existing = temp[key];
+        if (!isObject(existing) && !Array.isArray(existing)) {
+            // Same "can this be descended into?" test the loop head uses.
+            // Covers `undefined` (absent) as well as a pre-existing
+            // primitive. Replacing a primitive matches lodash `_.set` and
+            // the caller's explicit intent; leaving it in place made the
+            // write vanish with no signal.
+            (temp as Record<string, any>)[key] = NUMBER_REGEX.test(parts[index + 1] as string) ?
+                [] :
+                {};
         }
 
         index++;

--- a/test/unit/set-path-value.spec.ts
+++ b/test/unit/set-path-value.spec.ts
@@ -140,6 +140,61 @@ describe('intermediate container kind', () => {
         });
     });
 
+    it('treats a leading-zero segment as an object key, not an index', () => {
+        // '01' matches /^\d+$/ but is NOT a canonical array index —
+        // String(ToUint32('01')) is '1', not '01'. Creating an array here
+        // would hang `name` off it as a non-index property, which is exactly
+        // the serialization loss this change exists to prevent.
+        const obj: Record<string, any> = {};
+        setPathValue(obj, 'items.01.name', 'V');
+
+        expect(Array.isArray(obj.items)).toBe(false);
+        expect(obj).toEqual({
+            items: {
+                '01': {
+                    name: 'V' 
+                } 
+            } 
+        });
+        expect(JSON.parse(JSON.stringify(obj))).toEqual({
+            items: {
+                '01': {
+                    name: 'V' 
+                } 
+            } 
+        });
+    });
+
+    it('treats other non-canonical digit segments as object keys', () => {
+        for (const segment of ['007', '4294967295', '99999999999999999999']) {
+            const obj: Record<string, any> = {};
+            setPathValue(obj, `items.${segment}.x`, 'V');
+
+            expect(Array.isArray(obj.items)).toBe(false);
+            // 4294967295 is 2^32-1, one past the largest valid index.
+            expect(JSON.parse(JSON.stringify(obj))).toEqual({
+                items: {
+                    [segment]: {
+                        x: 'V' 
+                    } 
+                } 
+            });
+        }
+    });
+
+    it('treats the largest valid index as an index', () => {
+        // 2^32-2 is the last canonical index. Assertions stay targeted: the
+        // resulting sparse array has length 2^32-1, so serializing or deeply
+        // comparing it would be pathological.
+        const obj: Record<string, any> = {};
+        setPathValue(obj, 'items.4294967294.x', 'V');
+
+        expect(Array.isArray(obj.items)).toBe(true);
+        expect(obj.items[4294967294]).toEqual({
+            x: 'V' 
+        });
+    });
+
     it('survives a JSON round-trip', () => {
         // The regression this guards: non-index properties on an array are
         // dropped by JSON.stringify and structuredClone, so the value

--- a/test/unit/set-path-value.spec.ts
+++ b/test/unit/set-path-value.spec.ts
@@ -96,6 +96,179 @@ describe('setPathValue', () => {
     });
 });
 
+describe('intermediate container kind', () => {
+    // The container created at a key must be decided by the *next* segment.
+    // Deciding from the current key builds `{ a: { '0': [] } }` for `a[0].b`:
+    // structurally wrong, and the value is hung off an array as a non-index
+    // property, so it survives a property read but not serialization.
+
+    it('creates an array when the next segment is numeric', () => {
+        const obj: Record<string, any> = {};
+        setPathValue(obj, 'items.0.name', 'x');
+
+        expect(Array.isArray(obj.items)).toBe(true);
+        expect(obj).toEqual({
+            items: [{
+                name: 'x' 
+            }] 
+        });
+    });
+
+    it('creates an array for bracket notation too', () => {
+        const obj: Record<string, any> = {};
+        setPathValue(obj, 'a[0].b', 1);
+
+        expect(Array.isArray(obj.a)).toBe(true);
+        expect(obj).toEqual({
+            a: [{
+                b: 1 
+            }] 
+        });
+    });
+
+    it('creates a plain object when the next segment is not numeric', () => {
+        const obj: Record<string, any> = {};
+        setPathValue(obj, 'a.b.c', 1);
+
+        expect(Array.isArray(obj.a)).toBe(false);
+        expect(obj).toEqual({
+            a: {
+                b: {
+                    c: 1 
+                } 
+            } 
+        });
+    });
+
+    it('survives a JSON round-trip', () => {
+        // The regression this guards: non-index properties on an array are
+        // dropped by JSON.stringify and structuredClone, so the value
+        // disappears at any serialization boundary (an API response body,
+        // postMessage, IndexedDB) while still reading back in memory.
+        const obj: Record<string, any> = {};
+        setPathValue(obj, 'items.0.name', 'alpha');
+
+        expect(JSON.parse(JSON.stringify(obj))).toEqual({
+            items: [{
+                name: 'alpha' 
+            }] 
+        });
+        expect(structuredClone(obj)).toEqual({
+            items: [{
+                name: 'alpha' 
+            }] 
+        });
+    });
+
+    it('keeps a deep mixed path structurally correct', () => {
+        const obj: Record<string, any> = {};
+        setPathValue(obj, 'a.0.b.1.c', 'deep');
+
+        // The hole at `b[0]` serializes as null, per JSON semantics.
+        expect(JSON.parse(JSON.stringify(obj)))
+            .toEqual({
+                a: [{
+                    b: [null, {
+                        c: 'deep' 
+                    }] 
+                }] 
+            });
+    });
+
+    it('does not replace an existing object intermediate', () => {
+        const obj: Record<string, any> = {
+            a: {
+                keep: 1 
+            } 
+        };
+        setPathValue(obj, 'a.b', 2);
+
+        expect(obj).toEqual({
+            a: {
+                keep: 1,
+                b: 2 
+            } 
+        });
+    });
+
+    it('does not replace an existing array intermediate', () => {
+        const obj: Record<string, any> = {
+            a: [10, 20] 
+        };
+        setPathValue(obj, 'a.0', 99);
+
+        expect(Array.isArray(obj.a)).toBe(true);
+        expect(obj.a).toEqual([99, 20]);
+    });
+});
+
+describe('non-traversable intermediates', () => {
+    // Previously the guard was `typeof temp[key] === 'undefined'`, so a
+    // pre-existing null or primitive was neither replaced nor traversable —
+    // the loop bailed and the write vanished with no return value or throw
+    // to signal it. `{ address: null }` is ordinary initial state.
+
+    it('replaces a null intermediate instead of dropping the write', () => {
+        const obj: Record<string, any> = {
+            a: null 
+        };
+        setPathValue(obj, 'a.b', 1);
+
+        expect(obj).toEqual({
+            a: {
+                b: 1 
+            } 
+        });
+    });
+
+    it('replaces a string intermediate', () => {
+        const obj: Record<string, any> = {
+            a: 'str' 
+        };
+        setPathValue(obj, 'a.b', 1);
+
+        expect(obj).toEqual({
+            a: {
+                b: 1 
+            } 
+        });
+    });
+
+    it('replaces a numeric intermediate', () => {
+        const obj: Record<string, any> = {
+            a: 0 
+        };
+        setPathValue(obj, 'a.b', 1);
+
+        expect(obj).toEqual({
+            a: {
+                b: 1 
+            } 
+        });
+    });
+
+    it('replaces a null intermediate with an array when indexed numerically', () => {
+        const obj: Record<string, any> = {
+            a: null 
+        };
+        setPathValue(obj, 'a.0', 'first');
+
+        expect(Array.isArray(obj.a)).toBe(true);
+        expect(obj.a).toEqual(['first']);
+    });
+
+    it('still overwrites a primitive at the final segment', () => {
+        const obj: Record<string, any> = {
+            a: 'str' 
+        };
+        setPathValue(obj, 'a', 'replaced');
+
+        expect(obj).toEqual({
+            a: 'replaced' 
+        });
+    });
+});
+
 describe('avoid prototype pollution vulnerability', () => {
     it('exclude constructor', () => {
         const obj = {};


### PR DESCRIPTION
Closes #200.

Two defects in the same loop caused `setPathValue` to silently drop writes.

## 1. Array-vs-object creation read the wrong segment

```js
setPathValue({}, 'items.0.name', 'x');  // before: { items: { '0': [] } }
                                        // after:  { items: [ { name: 'x' } ] }
setPathValue({}, 'a[0].b', 1);          // before: { a: { '0': [] } }
                                        // after:  { a: [ { b: 1 } ] }
```

The check asked *"is the current key numeric?"* and, if so, created an array **at** that key. But a numeric current key means the **parent** should be an array — it says nothing about what belongs at `temp[key]`. The kind is now decided by the **next** segment, which is what actually determines how the slot gets indexed.

The old shape was quietly lossy rather than merely odd: `name` was assigned onto an array as a non-index property, so it read back fine in memory (`obj.items['0'].name === 'x'`) but disappeared through `JSON.stringify` and `structuredClone` — i.e. at every serialization boundary.

## 2. A non-traversable intermediate dropped the write

```js
setPathValue({ a: null },  'a.b', 1);  // before: { a: null }   after: { a: { b: 1 } }
setPathValue({ a: 'str' }, 'a.b', 1);  // before: { a: 'str' }  after: { a: { b: 1 } }
```

The guard was `typeof temp[key] === 'undefined'`, so a pre-existing `null` or primitive was never replaced. The loop descended into it, hit `if (!Array.isArray(temp) && !isObject(temp)) break`, and exited without writing — no return value, no throw, nothing to observe. `{ address: null }` is ordinary initial state for a form or DTO.

Replacing such intermediates matches lodash `_.set` and the caller's explicit intent. Failing silently was the worst of the available options; if overwriting is considered too aggressive, the alternative worth discussing is making the drop observable instead — but not leaving it as-is.

## Scope

Existing **objects and arrays** are still left in place, so behaviour only changes for paths that previously lost data. The `isUnsafeKey` guard and the prototype-pollution suite are untouched.

## Tests

12 specs added across two new describes. Verified by mutation — reverting `src/path-value/set.ts` and re-running:

```
with fix:     114 passed (114)
without fix:  8 failed | 106 passed (114)
```

The other four are guard-rails (existing intermediates preserved, primitive still overwritten at the final segment) and hold either way by design.

One pre-existing spec deserves a note: `allows nested array value to be set` asserts `obj.hello.universe[1].properties === 'galaxy'`, which passed **before** this fix despite `hello.universe` being a plain object rather than an array — a property read cannot see the difference. That is why the defect survived: the suite asserted read-back but never shape or serializability. The new specs assert `Array.isArray(...)`, full `toEqual` shapes, and a JSON round-trip.

`npx vitest run`, `npx eslint .` and `npx tsdown` all clean.

## Downstream

`validup` hits defect 1 in production code — `Container.finalizeOutput` expands its flat dotted output through `setPathValue`, so a glob mount over an array (`mount('items.*.name', …)`) returns `{ items: { '0': [] } }` under the default `flat: false` and loses every validated value on serialization.

`@validup/vue` additionally maintains its own `readNested` / `writeNested` purely to avoid defect 1, and grew a prototype-pollution hole in that copy because it never had `isUnsafeKey`. With this merged, that duplication can be deleted — which is the actual goal; the same traversal logic should not live in two repos.

The remaining blocker for full convergence is the codec: `arrayToPath(['tags', 0])` returns `'tags[0]'`, while that consumer needs a pure-dotted canonical form for prefix matching. Raised as an open question at the end of #200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deep path assignment when intermediate values are missing, null, or non-traversable.
  * Creates arrays or objects based on the next path segment, preserving the expected data structure.
  * Prevents nested values from being lost during serialization or cloning.
  * Preserves existing traversable objects and arrays during deeper updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->