### PR TITLE
ci: group dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,21 @@ updates:
           prefix: "fix"
           prefix-development: "build"
           include: "scope"
+      groups:
+          majorProd:
+              applies-to: version-updates
+              dependency-type: production
+              update-types:
+                  - "major"
+          majorDev:
+              applies-to: version-updates
+              dependency-type: development
+              exclude-patterns:
+                  - "eslint"
+              update-types:
+                  - "major"
+          minorAndPatch:
+              applies-to: version-updates
+              update-types:
+                  - "patch"
+                  - "minor"


### PR DESCRIPTION
`.github/dependabot.yml` here was `validup`'s config minus the `groups:` block, so every npm bump opens its own PR against an `open-pull-requests-limit` of 20.

Adds the same three groups `validup` already uses, **byte-identical** so the two configs stay diffable:

| group | scope |
|---|---|
| `majorProd` | production majors |
| `majorDev` | development majors, excluding `eslint` (its majors need hand-holding) |
| `minorAndPatch` | everything minor/patch |

`github-actions` updates are deliberately left ungrouped, matching `validup` — worth revisiting in both repos at once rather than letting the two configs drift apart here.

Config-only; no source or test changes.